### PR TITLE
fix: custom bush name from Tokenizable_strings if possible

### DIFF
--- a/Informant/Implementation/TooltipGenerator/CropTooltipGenerator.cs
+++ b/Informant/Implementation/TooltipGenerator/CropTooltipGenerator.cs
@@ -68,13 +68,13 @@ internal class CropTooltipGenerator : ITooltipGenerator<TerrainFeature>
         return ToDaysLeftString(modHelper, CalculateDaysLeft(crop));
     }
 
-    internal static string ToDaysLeftString(IModHelper modHelper, int daysLeft)
+    internal static string ToDaysLeftString(IModHelper modHelper, int daysLeft, bool bush=false)
     {
         return daysLeft switch {
             -1 => "", // something went very wrong, but we don't want to break the game
             0 => modHelper.Translation.Get("CropTooltipGenerator.0DaysLeft"),
-            1 => modHelper.Translation.Get("CropTooltipGenerator.1DayLeft"),
-            _ => modHelper.Translation.Get("CropTooltipGenerator.XDaysLeft", new { X = daysLeft })
+            1 => modHelper.Translation.Get(bush ? "CropTooltipGenerator.1DaysLeftMature" : "CropTooltipGenerator.1DayLeft"),
+            _ => modHelper.Translation.Get(bush ? "CropTooltipGenerator.XDaysLeftMature" : "CropTooltipGenerator.XDaysLeft", new { X = daysLeft })
         };
     }
 

--- a/Informant/Implementation/TooltipGenerator/TeaBushTooltipGenerator.cs
+++ b/Informant/Implementation/TooltipGenerator/TeaBushTooltipGenerator.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework;
 using Slothsoft.Informant.Api;
 using StardewValley.TerrainFeatures;
+using StardewValley.TokenizableStrings;
 using Informant.ThirdParty;
 using StardewValley.ItemTypeDefinitions;
 
@@ -50,6 +51,7 @@ internal class TeaBushTooltipGenerator : ITooltipGenerator<TerrainFeature>
             if (customBushApi.TryGetCustomBush(bush, out ICustomBush? customBushData, out string? id))
             {
                 displayName = customBushData.DisplayName;
+                if(displayName.Contains("LocalizedText")) displayName = TokenParser.ParseText(displayName);
                 willProduceThisSeason = customBushData.Seasons.Contains(Game1.season);
                 ageToMature = customBushData.AgeToProduce;
 

--- a/Informant/Implementation/TooltipGenerator/TeaBushTooltipGenerator.cs
+++ b/Informant/Implementation/TooltipGenerator/TeaBushTooltipGenerator.cs
@@ -1,6 +1,12 @@
-﻿using Microsoft.Xna.Framework;
+﻿using Informant.ThirdParty.CustomBush;
+using Microsoft.Xna.Framework;
 using Slothsoft.Informant.Api;
 using StardewValley.TerrainFeatures;
+using Informant.ThirdParty;
+using StardewValley;
+using StardewValley.ItemTypeDefinitions;
+using System.Diagnostics.CodeAnalysis;
+using StardewModdingAPI.Utilities;
 
 namespace Slothsoft.Informant.Implementation.TooltipGenerator;
 
@@ -19,6 +25,8 @@ internal class TeaBushTooltipGenerator : ITooltipGenerator<TerrainFeature>
     public string DisplayName => _modHelper.Translation.Get("TeaBushTooltipGenerator");
     public string Description => _modHelper.Translation.Get("TeaBushTooltipGenerator.Description");
 
+    public string NotThisSeason => _modHelper.Translation.Get("CustomBushTooltipGenerator.NotThisSeason");
+
     public bool HasTooltip(TerrainFeature input)
     {
         return input is Bush bush && !bush.townBush.Value && bush.size.Value == Bush.greenTeaBush;
@@ -31,15 +39,65 @@ internal class TeaBushTooltipGenerator : ITooltipGenerator<TerrainFeature>
 
     private Tooltip CreateTooltip(Bush bush)
     {
+        // Default values for regular tea bush
         var item = ItemRegistry.GetDataOrErrorItem(bush.GetShakeOffItem());
         var displayName = item.DisplayName;
-        var daysLeft = CropTooltipGenerator.ToDaysLeftString(_modHelper, CalculateDaysLeft(bush));
-        return new Tooltip($"{displayName}\n{daysLeft}") {
+        var daysLeft = CalculateDaysLeft(bush);
+        var ageToMature = Bush.daysToMatureGreenTeaBush;
+        var willProduceThisSeason = true;
+
+        // Handle custom bush logic
+        if (HookToCustomBush.GetApi(out ICustomBushApi? customBushApi))
+        {
+            if (customBushApi.TryGetCustomBush(bush, out ICustomBush? customBushData, out string? id))
+            {
+                displayName = customBushData.DisplayName;
+                willProduceThisSeason = customBushData.Seasons.Contains(Game1.season);
+                ageToMature = customBushData.AgeToProduce;
+
+                // Handle custom drops
+                if (customBushApi.TryGetDrops(id, out IList<ICustomBushDrop>? drops) &&
+                    drops != null && drops.Count > 0)
+                {
+                    item = ItemRegistry.GetDataOrErrorItem(drops[0].ItemId);
+                }
+
+                daysLeft = CalculateCustomBushDaysLeft(bush, customBushData, id);
+            }
+        }
+
+        // Construct tooltip text
+        // Determine if the bush is still maturing
+        bool isMaturing = bush.getAge() < ageToMature;
+        var daysLeftText = CropTooltipGenerator.ToDaysLeftString(_modHelper, daysLeft, isMaturing);
+
+        // Construct tooltip text
+        string tooltipText = displayName;
+
+        if (isMaturing)
+        {
+            // Bush is still growing; show days until maturity
+            tooltipText += $"\n{daysLeftText}";
+
+            // If it's not in season, show additional note
+            if (!willProduceThisSeason)
+            {
+                tooltipText += $"\n{NotThisSeason}";
+            }
+        }
+        else
+        {
+            // Bush is mature; show days until the next production or Out of season
+            tooltipText += $"\n{(willProduceThisSeason ? daysLeftText : NotThisSeason)}";
+        }
+
+        return new Tooltip(tooltipText)
+        {
             Icon = [Icon.ForUnqualifiedItemId(
-                    item.QualifiedItemId,
-                    IPosition.CenterRight,
-                    new Vector2(Game1.tileSize / 2, Game1.tileSize / 2)
-            )]
+            item.QualifiedItemId,
+            IPosition.CenterRight,
+            new Vector2(Game1.tileSize / 2, Game1.tileSize / 2)
+        )]
         };
     }
 
@@ -50,7 +108,8 @@ internal class TeaBushTooltipGenerator : ITooltipGenerator<TerrainFeature>
     /// </summary>
     internal int CalculateDaysLeft(Bush bush)
     {
-        if (bush.tileSheetOffset.Value == 1) {
+        if (bush.tileSheetOffset.Value == 1)
+        {
             // has tea leaves
             return 0;
         }
@@ -64,17 +123,104 @@ internal class TeaBushTooltipGenerator : ITooltipGenerator<TerrainFeature>
         // add up the next closest bloom day
         daysLeft += _bloomWeek.Contains(bloomDay) ? 1 : _bloomWeek.First() - bloomDay;
 
-        if (daysLeft < 0) {
+        if (daysLeft < 0)
+        {
             // fully grown
             daysLeft += WorldDate.DaysPerMonth;
         }
 
         int nextSeason = (daysLeft + today) / WorldDate.DaysPerMonth;
         // outdoor tea bush cannot shake in winter
-        if (!bush.IsSheltered() && Game1.Date.SeasonIndex + nextSeason == (int)Season.Winter) {
+        if (!bush.IsSheltered() && Game1.Date.SeasonIndex + nextSeason == (int)Season.Winter)
+        {
             daysLeft += WorldDate.DaysPerMonth;
         }
 
         return daysLeft;
+    }
+
+    internal static int CalculateCustomBushDaysLeft(Bush bush, ICustomBush customBushData, string id)
+    {
+        var today = SDate.Now();
+        var nextHarvestDate = GetNextHarvestDate(bush, customBushData);
+
+        // If bush isn't mature yet, calculate days until maturity
+        var bushAge = bush.getAge();
+        if (bushAge < customBushData.AgeToProduce)
+        {
+            return Math.Max(0, customBushData.AgeToProduce - bushAge + 1);
+        }
+
+        // For mature bushes, return days until next harvest
+        int daysUntilHarvest = GetDaysBetween(today, nextHarvestDate);
+        return Math.Max(0, daysUntilHarvest);
+    }
+
+    internal static SDate GetNextHarvestDate(Bush bush, ICustomBush customBush)
+    {
+        SDate today = SDate.Now();
+        var tomorrow = today.AddDays(1);
+
+        // currently has produce
+        if (bush.tileSheetOffset.Value == 1)
+            return today;
+
+        // tea bush and custom bush
+        int dayToBegin = customBush.DayToBeginProducing;
+        if (dayToBegin >= 0)
+        {
+            SDate readyDate = GetDateFullyGrown(bush, customBush);
+            if (readyDate < tomorrow)
+                readyDate = tomorrow;
+
+            if (!bush.IsSheltered())
+            {
+                // bush not sheltered, must check producing seasons
+                List<Season> producingSeasons = customBush.Seasons;
+                SDate seasonDate = new(Math.Max(1, dayToBegin), readyDate.Season, readyDate.Year);
+                while (!producingSeasons.Contains(seasonDate.Season))
+                    seasonDate = seasonDate.AddDays(28);
+
+                if (readyDate < seasonDate)
+                    return seasonDate;
+            }
+
+            if (readyDate.Day < dayToBegin)
+                readyDate = new(dayToBegin, readyDate.Season, readyDate.Year);
+
+            return readyDate;
+        }
+
+        // wild bushes produce salmonberries in spring 15-18, and blackberries in fall 8-11
+        SDate springStart = new(15, Season.Spring);
+        SDate springEnd = new(18, Season.Spring);
+        SDate fallStart = new(8, Season.Fall);
+        SDate fallEnd = new(11, Season.Fall);
+
+        if (tomorrow < springStart)
+            return springStart;
+        if (tomorrow > springEnd && tomorrow < fallStart)
+            return fallStart;
+        if (tomorrow > fallEnd)
+            return new(springStart.Day, springStart.Season, springStart.Year + 1);
+        return tomorrow;
+    }
+
+    internal static SDate GetDateFullyGrown(Bush bush, ICustomBush customBush)
+    {
+        SDate date = new(1, Season.Spring, 1);
+        date = date.AddDays(bush.datePlanted.Value);
+        date = date.AddDays(customBush.AgeToProduce);
+
+        return date;
+    }
+
+    internal static int GetDaysBetween(SDate start, SDate end)
+    {
+        // Convert both dates to total days since game start
+        int startDays = start.DaysSinceStart;
+        int endDays = end.DaysSinceStart;
+
+        return endDays - startDays;
     }
 }

--- a/Informant/Informant.csproj
+++ b/Informant/Informant.csproj
@@ -3,8 +3,6 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	  <EnableHarmony>true</EnableHarmony>
-
   </PropertyGroup>
   <Import Project="..\build\common.targets" />
   <ItemGroup>

--- a/Informant/Informant.csproj
+++ b/Informant/Informant.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+	  <EnableHarmony>true</EnableHarmony>
+
   </PropertyGroup>
   <Import Project="..\build\common.targets" />
   <ItemGroup>

--- a/Informant/InformantMod.cs
+++ b/Informant/InformantMod.cs
@@ -1,4 +1,5 @@
-﻿using Slothsoft.Informant.Api;
+﻿using Informant.ThirdParty;
+using Slothsoft.Informant.Api;
 using Slothsoft.Informant.Implementation.Decorator;
 using Slothsoft.Informant.Implementation.TooltipGenerator;
 using Slothsoft.Informant.ThirdParty;
@@ -45,6 +46,7 @@ public class InformantMod : Mod
     private void OnGameLaunched(object? sender, GameLaunchedEventArgs e)
     {
         HookToGenericModConfigMenu.Apply(this, _api!);
+        HookToCustomBush.Apply(this);
     }
 
     public override IInformant? GetApi()

--- a/Informant/ThirdParty/CustomBush/CustomBushExtensions.cs
+++ b/Informant/ThirdParty/CustomBush/CustomBushExtensions.cs
@@ -1,0 +1,209 @@
+﻿using StardewValley.Extensions;
+using StardewValley.ItemTypeDefinitions;
+using StardewValley.TerrainFeatures;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Informant.ThirdParty.CustomBush;
+internal static class CustomBushExtensions
+{
+    private const string ShakeOffItem = "furyx639.CustomBush/ShakeOff";
+
+    public static bool GetShakeOffItemIfReady(
+        this ICustomBush customBush,
+        Bush bush,
+        [NotNullWhen(true)] out ParsedItemData? item
+      )
+    {
+        item = null;
+        if (bush.size.Value != Bush.greenTeaBush)
+        {
+            return false;
+        }
+
+        if (!bush.modData.TryGetValue(ShakeOffItem, out string itemId))
+        {
+            return false;
+        }
+
+        item = ItemRegistry.GetData(itemId);
+        return true;
+    }
+
+    public static List<PossibleDroppedItem> GetCustomBushDropItems(
+        this ICustomBushApi api,
+        ICustomBush bush,
+        string? id,
+        bool includeToday = false
+      )
+    {
+        if (id == null || string.IsNullOrEmpty(id))
+        {
+            return new List<PossibleDroppedItem>();
+        }
+
+        api.TryGetDrops(id, out IList<ICustomBushDrop>? drops);
+        return drops == null
+          ? new List<PossibleDroppedItem>()
+          : GetGenericDropItems(drops, id, includeToday, bush.DisplayName, BushDropConverter);
+
+        DropInfo BushDropConverter(ICustomBushDrop input)
+        {
+            return new DropInfo(input.Condition, input.Chance, input.ItemId);
+        }
+    }
+
+    public static List<PossibleDroppedItem> GetGenericDropItems<T>(
+    IEnumerable<T> drops,
+    string? customId,
+    bool includeToday,
+    string displayName,
+    Func<T, DropInfo> extractDropInfo
+  )
+    {
+        List<PossibleDroppedItem> items = new();
+
+        foreach (T drop in drops)
+        {
+            DropInfo dropInfo = extractDropInfo(drop);
+            int? nextDay = GetNextDay(dropInfo.Condition, includeToday);
+            int? lastDay = GetLastDay(dropInfo.Condition);
+
+            if (!nextDay.HasValue)
+            {
+                if (!lastDay.HasValue)
+                {
+                }
+
+                continue;
+            }
+
+            ParsedItemData? itemData = ItemRegistry.GetData(dropInfo.ItemId);
+            if (itemData == null)
+            {
+                continue;
+            }
+
+            if (Game1.dayOfMonth == nextDay.Value && !includeToday)
+            {
+                continue;
+            }
+
+            items.Add(new PossibleDroppedItem(nextDay.Value, itemData, dropInfo.Chance, customId));
+        }
+
+        return items;
+    }
+
+    public static int? GetNextDay(string? condition, bool includeToday)
+    {
+        return string.IsNullOrEmpty(condition)
+          ? Game1.dayOfMonth + (includeToday ? 0 : 1)
+          : GetNextDayFromCondition(condition, includeToday);
+    }
+
+    public static int? GetLastDay(string? condition)
+    {
+        return GetLastDayFromCondition(condition);
+    }
+
+    public record PossibleDroppedItem(int NextDayToProduce, ParsedItemData Item, float Chance, string? CustomId = null)
+    {
+        public bool ReadyToPick => Game1.dayOfMonth == NextDayToProduce;
+    }
+
+    public record DropInfo(string? Condition, float Chance, string ItemId)
+    {
+        public int? GetNextDay(bool includeToday)
+        {
+            return LocalGetNextDay(Condition, includeToday);
+        }
+    }
+
+    public static int? LocalGetNextDay(string? condition, bool includeToday)
+    {
+        return string.IsNullOrEmpty(condition)
+          ? Game1.dayOfMonth + (includeToday ? 0 : 1)
+          : GetNextDayFromCondition(condition, includeToday);
+    }
+
+    public static int? GetNextDayFromCondition(string? condition, bool includeToday = true)
+    {
+        HashSet<int> days = new();
+        if (condition == null)
+        {
+            return null;
+        }
+
+        GameStateQuery.ParsedGameStateQuery[]? conditionEntries = GameStateQuery.Parse(condition);
+
+        foreach (GameStateQuery.ParsedGameStateQuery parsedGameStateQuery in conditionEntries)
+        {
+            days.AddRange(GetDaysFromCondition(parsedGameStateQuery));
+        }
+
+        days.RemoveWhere(day => day < Game1.dayOfMonth || (!includeToday && day == Game1.dayOfMonth));
+
+        return days.Count == 0 ? null : days.Min();
+    }
+
+    public static IEnumerable<int> GetDaysFromCondition(GameStateQuery.ParsedGameStateQuery parsedGameStateQuery)
+    {
+        HashSet<int> days = new();
+        if (parsedGameStateQuery.Query.Length < 2)
+        {
+            return days;
+        }
+
+        string queryStr = parsedGameStateQuery.Query[0];
+        if (!"day_of_month".Equals(queryStr, StringComparison.OrdinalIgnoreCase))
+        {
+            return days;
+        }
+
+        for (var i = 1; i < parsedGameStateQuery.Query.Length; i++)
+        {
+            string dayStr = parsedGameStateQuery.Query[i];
+            if ("even".Equals(dayStr, StringComparison.OrdinalIgnoreCase))
+            {
+                days.AddRange(Enumerable.Range(1, 28).Where(x => x % 2 == 0));
+                continue;
+            }
+
+            if ("odd".Equals(dayStr, StringComparison.OrdinalIgnoreCase))
+            {
+                days.AddRange(Enumerable.Range(1, 28).Where(x => x % 2 != 0));
+                continue;
+            }
+
+            try
+            {
+                int parsedInt = int.Parse(dayStr);
+                days.Add(parsedInt);
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+        }
+
+        return parsedGameStateQuery.Negated ? Enumerable.Range(1, 28).Where(x => !days.Contains(x)).ToHashSet() : days;
+    }
+
+    public static int? GetLastDayFromCondition(string? condition)
+    {
+        HashSet<int> days = new();
+        if (condition == null)
+        {
+            return null;
+        }
+
+        GameStateQuery.ParsedGameStateQuery[]? conditionEntries = GameStateQuery.Parse(condition);
+
+        foreach (GameStateQuery.ParsedGameStateQuery parsedGameStateQuery in conditionEntries)
+        {
+            days.AddRange(GetDaysFromCondition(parsedGameStateQuery));
+        }
+
+        return days.Count == 0 ? null : days.Max();
+    }
+}

--- a/Informant/ThirdParty/CustomBush/ICustomBush.cs
+++ b/Informant/ThirdParty/CustomBush/ICustomBush.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using StardewValley;
+using StardewValley.GameData;
+
+namespace Informant.ThirdParty.CustomBush;
+
+/// <summary>Model used for custom bushes.</summary>
+public interface ICustomBush
+{
+    /// <summary>Gets the age needed to produce.</summary>
+    public int AgeToProduce { get; }
+
+    /// <summary>Gets the day of month to begin producing.</summary>
+    public int DayToBeginProducing { get; }
+
+    /// <summary>Gets the description of the bush.</summary>
+    public string Description { get; }
+
+    /// <summary>Gets the display name of the bush.</summary>
+    public string DisplayName { get; }
+
+    /// <summary>Gets the default texture used when planted indoors.</summary>
+    public string IndoorTexture { get; }
+
+    /// <summary>Gets the season in which this bush will produce its drops.</summary>
+    public List<Season> Seasons { get; }
+
+    /// <summary>Gets the rules which override the locations that custom bushes can be planted in.</summary>
+    public List<PlantableRule> PlantableLocationRules { get; }
+
+    /// <summary>Gets the texture of the tea bush.</summary>
+    public string Texture { get; }
+
+    /// <summary>Gets the row index for the custom bush's sprites.</summary>
+    public int TextureSpriteRow { get; }
+}

--- a/Informant/ThirdParty/CustomBush/ICustomBushApi.cs
+++ b/Informant/ThirdParty/CustomBush/ICustomBushApi.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using StardewValley.TerrainFeatures;
+
+namespace Informant.ThirdParty.CustomBush;
+
+/// <summary>Mod API for custom bushes.</summary>
+public interface ICustomBushApi
+{
+    /// <summary>Retrieves the data model for all Custom Bush.</summary>
+    /// <returns>An enumerable of objects implementing the ICustomBush interface. Each object represents a custom bush.</returns>
+    public IEnumerable<(string Id, ICustomBush Data)> GetData();
+
+    /// <summary>Determines if the given Bush instance is a custom bush.</summary>
+    /// <param name="bush">The bush instance to check.</param>
+    /// <returns>true if the bush is a custom bush, otherwise false.</returns>
+    public bool IsCustomBush(Bush bush);
+
+    /// <summary>Tries to get the custom bush model associated with the given bush.</summary>
+    /// <param name="bush">The bush.</param>
+    /// <param name="customBush">
+    ///   When this method returns, contains the custom bush associated with the given bush, if found;
+    ///   otherwise, it contains null.
+    /// </param>
+    /// <returns>true if the custom bush associated with the given bush is found; otherwise, false.</returns>
+    public bool TryGetCustomBush(Bush bush, [NotNullWhen(true)] out ICustomBush? customBush);
+
+    /// <summary>Tries to get the custom bush model associated with the given bush.</summary>
+    /// <param name="bush">The bush.</param>
+    /// <param name="customBush">
+    ///   When this method returns, contains the custom bush associated with the given bush, if found;
+    ///   otherwise, it contains null.
+    /// </param>
+    /// <param name="id">When this method returns, contains the id of the custom bush, if found; otherwise, it contains null.</param>
+    /// <returns>true if the custom bush associated with the given bush is found; otherwise, false.</returns>
+    public bool TryGetCustomBush(
+      Bush bush,
+      [NotNullWhen(true)] out ICustomBush? customBush,
+      [NotNullWhen(true)] out string? id
+    );
+
+    /// <summary>Tries to get the custom bush drop associated with the given bush id.</summary>
+    /// <param name="id">The id of the bush.</param>
+    /// <param name="drops">When this method returns, contains the items produced by the custom bush.</param>
+    /// <returns>true if the drops associated with the given id is found; otherwise, false.</returns>
+    public bool TryGetDrops(string id, [NotNullWhen(true)] out IList<ICustomBushDrop>? drops);
+}

--- a/Informant/ThirdParty/CustomBush/ICustomBushDrop.cs
+++ b/Informant/ThirdParty/CustomBush/ICustomBushDrop.cs
@@ -1,0 +1,25 @@
+﻿using StardewValley;
+using StardewValley.GameData;
+
+namespace Informant.ThirdParty.CustomBush;
+
+/// <summary>Model used for drops from custom bushes.</summary>
+public interface ICustomBushDrop : ISpawnItemData
+{
+    /// <summary>Gets the specific season when the item can be produced.</summary>
+    public Season? Season { get; }
+
+    /// <summary>Gets the probability that the item will be produced.</summary>
+    public float Chance { get; }
+
+    /// <summary>A game state query which indicates whether the item should be added. Defaults to always added.</summary>
+    public string? Condition { get; }
+
+    /// <summary>
+    ///   An ID for this entry within the current list (not the item itself, which is
+    ///   <see cref="P:StardewValley.GameData.GenericSpawnItemData.ItemId" />). This only needs to be unique within the current
+    ///   list. For a custom entry, you should use a globally unique ID which includes your mod ID like
+    ///   <c>ExampleMod.Id_ItemName</c>.
+    /// </summary>
+    public string? Id { get; }
+}

--- a/Informant/ThirdParty/HookToCustomBush.cs
+++ b/Informant/ThirdParty/HookToCustomBush.cs
@@ -1,0 +1,42 @@
+﻿using Informant.ThirdParty.CustomBush;
+using Slothsoft.Informant;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Informant.ThirdParty;
+
+public static class HookToCustomBush
+{
+    private const string ModId = "furyx639.CustomBush";
+    private static readonly Dictionary<string, object> RegisteredApis = new();
+
+    public static void Apply(InformantMod informantMod)
+    {
+        var customBush = informantMod.Helper.ModRegistry.GetApi<ICustomBushApi>(ModId);
+        if (customBush == null)
+        {
+            return;
+        }
+        RegisteredApis[ModId] = customBush;
+    }
+
+    public static bool GetApi<T>([NotNullWhen(true)] out T? apiInstance) where T : class
+    {
+        apiInstance = null;
+        if (!RegisteredApis.TryGetValue(ModId, out object? api))
+        {
+            return false;
+        }
+
+        if (api is T apiVal)
+        {
+            apiInstance = apiVal;
+            return true;
+        }
+        return false;
+    }
+}

--- a/Informant/i18n/de.json
+++ b/Informant/i18n/de.json
@@ -50,6 +50,11 @@
   "TeaBushTooltipGenerator": "Tea Bush Tooltip",
   "TeaBushTooltipGenerator.Description": "A tooltip that displays the remaining days of tea bush",
 
+  "CustomBushToolTipGenerator.NotThisSeason": "Does not produce this season",
+  "CustomBushToolTipGenerator.NotThisSeasonAnymore": "Does not produce this season anymore",
+  "CropTooltipGenerator.1DayLeftMature": "1 day left to mature",
+  "CropTooltipGenerator.XDaysLeftMature": "{{X}} days left to mature",
+  
   "MachineTooltipGenerator": "Machinen-Tooltip",
   "MachineTooltipGenerator.Description": "Ein Tooltip, der die Art des Erzeugnisses und die verbleibende Zeit zeigt",
   "MachineTooltipGenerator.Finished": "Fertig",

--- a/Informant/i18n/default.json
+++ b/Informant/i18n/default.json
@@ -50,6 +50,10 @@
   "TeaBushTooltipGenerator": "Tea Bush Tooltip",
   "TeaBushTooltipGenerator.Description": "A tooltip that displays the remaining days of tea bush",
 
+  "CustomBushToolTipGenerator.NotThisSeason": "Does not produce this season",
+  "CropTooltipGenerator.1DayLeftMature": "1 day left to mature",
+  "CropTooltipGenerator.XDaysLeftMature": "{{X}} days left to mature",
+
   "MachineTooltipGenerator": "Machines Tooltip",
   "MachineTooltipGenerator.Description": "A tooltip that displays the type of result and remaining time",
   "MachineTooltipGenerator.Finished": "Finished",

--- a/Informant/i18n/default.json
+++ b/Informant/i18n/default.json
@@ -51,6 +51,7 @@
   "TeaBushTooltipGenerator.Description": "A tooltip that displays the remaining days of tea bush",
 
   "CustomBushToolTipGenerator.NotThisSeason": "Does not produce this season",
+  "CustomBushToolTipGenerator.NotThisSeasonAnymore": "Does not produce this season anymore",
   "CropTooltipGenerator.1DayLeftMature": "1 day left to mature",
   "CropTooltipGenerator.XDaysLeftMature": "{{X}} days left to mature",
 

--- a/Informant/i18n/es.json
+++ b/Informant/i18n/es.json
@@ -50,6 +50,11 @@
   "TeaBushTooltipGenerator": "Descripción Emergente de Arbustos de Té",
   "TeaBushTooltipGenerator.Description": "Una descripción emergente que muestra los días restantes del arbusto de té",
 
+  "CustomBushToolTipGenerator.NotThisSeason": "Does not produce this season",
+  "CustomBushToolTipGenerator.NotThisSeasonAnymore": "Does not produce this season anymore",
+  "CropTooltipGenerator.1DayLeftMature": "1 day left to mature",
+  "CropTooltipGenerator.XDaysLeftMature": "{{X}} days left to mature",
+  
   "MachineTooltipGenerator": "Descripción Emergente de Máquinas",
   "MachineTooltipGenerator.Description": "Una descripción emergente que muestra el tipo de resultado y el tiempo restante",
   "MachineTooltipGenerator.Finished": "Finalizado",

--- a/Informant/i18n/fr.json
+++ b/Informant/i18n/fr.json
@@ -50,6 +50,11 @@
   "TeaBushTooltipGenerator": "Infobulle du plant de thé",
   "TeaBushTooltipGenerator.Description": "Une infobulle qui affiche le temps restant avant la récolte d'un plant de thé.",
 
+  "CustomBushToolTipGenerator.NotThisSeason": "Does not produce this season",
+  "CustomBushToolTipGenerator.NotThisSeasonAnymore": "Does not produce this season anymore",
+  "CropTooltipGenerator.1DayLeftMature": "1 day left to mature",
+  "CropTooltipGenerator.XDaysLeftMature": "{{X}} days left to mature",
+  
   "MachineTooltipGenerator": "Infobulle des machines",
   "MachineTooltipGenerator.Description": "Une infobulle qui affiche le type de résultat et le temps restant.",
   "MachineTooltipGenerator.Finished": "Fini",

--- a/Informant/i18n/ko.json
+++ b/Informant/i18n/ko.json
@@ -50,6 +50,11 @@
   "TeaBushTooltipGenerator": "Tea Bush Tooltip",
   "TeaBushTooltipGenerator.Description": "A tooltip that displays the remaining days of tea bush",
 
+  "CustomBushToolTipGenerator.NotThisSeason": "Does not produce this season",
+  "CustomBushToolTipGenerator.NotThisSeasonAnymore": "Does not produce this season anymore",
+  "CropTooltipGenerator.1DayLeftMature": "1 day left to mature",
+  "CropTooltipGenerator.XDaysLeftMature": "{{X}} days left to mature",
+  
   "MachineTooltipGenerator": "기계 정보",
   "MachineTooltipGenerator.Description": "기계의 결과물과 남은 시간을 보여줍니다",
   "MachineTooltipGenerator.Finished": "완료",

--- a/Informant/i18n/pt.json
+++ b/Informant/i18n/pt.json
@@ -50,6 +50,11 @@
   "TeaBushTooltipGenerator": "Tea Bush Tooltip",
   "TeaBushTooltipGenerator.Description": "A tooltip that displays the remaining days of tea bush",
 
+  "CustomBushToolTipGenerator.NotThisSeason": "Does not produce this season",
+  "CustomBushToolTipGenerator.NotThisSeasonAnymore": "Does not produce this season anymore",
+  "CropTooltipGenerator.1DayLeftMature": "1 day left to mature",
+  "CropTooltipGenerator.XDaysLeftMature": "{{X}} days left to mature",
+  
   "MachineTooltipGenerator": "Tooltip de Máquinas",
   "MachineTooltipGenerator.Description": "Uma Tooltip que exibe o tipo de resultado e o tempo restante",
   "MachineTooltipGenerator.Finished": "Finalizado",

--- a/Informant/i18n/tr.json
+++ b/Informant/i18n/tr.json
@@ -50,6 +50,11 @@
   "TeaBushTooltipGenerator": "Tea Bush Tooltip",
   "TeaBushTooltipGenerator.Description": "A tooltip that displays the remaining days of tea bush",
 
+  "CustomBushToolTipGenerator.NotThisSeason": "Does not produce this season",
+  "CustomBushToolTipGenerator.NotThisSeasonAnymore": "Does not produce this season anymore",
+  "CropTooltipGenerator.1DayLeftMature": "1 day left to mature",
+  "CropTooltipGenerator.XDaysLeftMature": "{{X}} days left to mature",
+  
   "MachineTooltipGenerator": "Makine İpucu",
   "MachineTooltipGenerator.Description": "Üretilen nesnenin türünü ve kalan süreyi gösteren bir ipucu",
   "MachineTooltipGenerator.Finished": "Tamamlandı",

--- a/Informant/i18n/zh.json
+++ b/Informant/i18n/zh.json
@@ -50,6 +50,11 @@
 	"TeaBushTooltipGenerator": "茶树",
 	"TeaBushTooltipGenerator.Description": "茶树相关的信息, 如下次收获日",
 
+	"CustomBushToolTipGenerator.NotThisSeason": "Does not produce this season",
+	"CustomBushToolTipGenerator.NotThisSeasonAnymore": "Does not produce this season anymore",
+	"CropTooltipGenerator.1DayLeftMature": "1 day left to mature",
+	"CropTooltipGenerator.XDaysLeftMature": "{{X}} days left to mature",
+
 	"MachineTooltipGenerator": "机器",
 	"MachineTooltipGenerator.Description": "机器相关的信息, 如产物, 剩余时间",
 	"MachineTooltipGenerator.Finished": "已完成",


### PR DESCRIPTION
fix: custom bush name from Tokenizable_strings if possible
![20241027102554_1](https://github.com/user-attachments/assets/772d00dc-4667-41d4-8e48-11b0b40a0b39)
![20241027102546_1](https://github.com/user-attachments/assets/09820af2-acc3-4910-9f1a-f7b705cf7e4a)
