### PR TITLE
fix: custom bush name from Tokenizable_strings if possible

### DIFF
--- a/Informant/Implementation/TooltipGenerator/TeaBushTooltipGenerator.cs
+++ b/Informant/Implementation/TooltipGenerator/TeaBushTooltipGenerator.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework;
 using Slothsoft.Informant.Api;
 using StardewValley.TerrainFeatures;
+using StardewValley.TokenizableStrings;
 using Informant.ThirdParty;
 using StardewValley.ItemTypeDefinitions;
 
@@ -50,6 +51,7 @@ internal class TeaBushTooltipGenerator : ITooltipGenerator<TerrainFeature>
             if (customBushApi.TryGetCustomBush(bush, out ICustomBush? customBushData, out string? id))
             {
                 displayName = customBushData.DisplayName;
+                if(displayName.Contains("LocalizedText")) displayName = TokenParser.ParseText(displayName);
                 willProduceThisSeason = customBushData.Seasons.Contains(Game1.season);
                 ageToMature = customBushData.AgeToProduce;
 


### PR DESCRIPTION
fix: custom bush name from Tokenizable_strings if possible
![20241027102554_1](https://github.com/user-attachments/assets/37849fda-20aa-4844-a28f-c0d71b7db881)
![20241027102546_1](https://github.com/user-attachments/assets/429c3cb0-6643-40f4-be80-ae67016a2dd6)
![20241027102542_1](https://github.com/user-attachments/assets/d67e6859-d037-4431-aeca-29c05901ff3d)
