### PR TITLE
fix: possible null key

### DIFF
--- a/Informant.Aquarium/manifest.json
+++ b/Informant.Aquarium/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Informant Aquarium Addon",
   "Author": "DK",
-  "Version": "1.9.5",
+  "Version": "1.9.100",
   "Description": "Informant Addon for Stardew Aquarium",
   "UniqueID": "Slothsoft.Informant.Aquarium",
   "EntryDll": "Informant.Aquarium.dll",

--- a/Informant/Implementation/Decorator/SeedDecorator.cs
+++ b/Informant/Implementation/Decorator/SeedDecorator.cs
@@ -52,11 +52,15 @@ internal class SeedDecorator : IDecorator<Item>
         var decorations = CachedCropData[input.ItemId].HarvestId
             .Select(crop => {
                 _ = ItemRegistry.GetDataOrErrorItem(crop);
+                if (string.IsNullOrEmpty(crop)) {
+                    return null;
+                }
                 var monoItem = ItemRegistry.Create(crop);
                 return new Decoration(GetOrCacheCropTexture(crop)) {
                     Counter = Utility.getSellToStorePriceOfItem(monoItem),
                 };
             })
+            .OfType<Decoration>()
             .ToArray();
         return decorations[0] with { ExtraDecorations = decorations[1..] };
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent crash in SeedDecorator when HarvestId contains null or empty crop keys by skipping them and filtering null decorations. Bumps the Aquarium addon manifest version to 1.9.100.

<sup>Written for commit 916b40ee7b513fa73a17d478ca968e08e6a17b37. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

